### PR TITLE
Chore : SecurityConfig 수정

### DIFF
--- a/src/main/java/com/zipkimi/global/config/SecurityConfig.java
+++ b/src/main/java/com/zipkimi/global/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig  {
                 // 회원가입(userMgmt), 로그인 및 아이디/비밀번호 찾기(users)을 위한 요청은 검증 없이 요청을 허용함
                 .and()
                 .authorizeRequests()
-                .antMatchers("/api/v1/userMgmt/**").permitAll()
+                .antMatchers("/api/v1/userMgmt/users/**").permitAll()
                 .antMatchers("/api/v1/users/auth/sign").permitAll()
                 .antMatchers("/api/v1/users/auth/login").permitAll()
                 .antMatchers("/api/v1/users/find-id/**").permitAll()


### PR DESCRIPTION
## 요약

- UserManageControllerTest 시 permitAll 경로 문제 발생 (302 에러)
- 기존 경로에서 "/api/v1/userMgmt/users/**"으로 수정

Related to: #27

<br><br>

## 작업 내용

- UserManageControllerTest 시 permitAll 경로 문제 발생 (302 에러)
- 기존 경로에서 "/api/v1/userMgmt/users/**"으로 수정

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #27 

<br><br>

