### PR TITLE
 Feat : 시공사 회원가입 - SMS 확인 메서드 추가

### DIFF
--- a/src/main/java/com/zipkimi/builder/controller/BuilderManagementController.java
+++ b/src/main/java/com/zipkimi/builder/controller/BuilderManagementController.java
@@ -1,9 +1,16 @@
 package com.zipkimi.builder.controller;
 
 import com.zipkimi.builder.service.BuilderManagementService;
+import com.zipkimi.user.dto.request.SmsAuthNumberPostRequest;
+import com.zipkimi.user.dto.response.SmsAuthNumberPostResponse;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,9 +18,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @AllArgsConstructor
 @Api(value = "시공사 회원 관리")
-@RequestMapping("/api/v1/builders")
+@RequestMapping("/api/v1/builderMgmt/builders")
 public class BuilderManagementController {
 
     private BuilderManagementService builderManagementService;
+
+    @ApiOperation(value = "SMS 인증번호 전송")
+    @PostMapping(value = "/sms")
+    public ResponseEntity<SmsAuthNumberPostResponse> sendBuilderUserJoinSmsAuthNumber(@RequestBody
+            SmsAuthNumberPostRequest requestDto){
+        return ResponseEntity.status(HttpStatus.OK).body(builderManagementService.sendBuilderUserJoinSmsAuthNumber(requestDto));
+    }
 
 }

--- a/src/main/java/com/zipkimi/builder/controller/BuilderManagementController.java
+++ b/src/main/java/com/zipkimi/builder/controller/BuilderManagementController.java
@@ -1,7 +1,9 @@
 package com.zipkimi.builder.controller;
 
 import com.zipkimi.builder.service.BuilderManagementService;
+import com.zipkimi.user.dto.request.SmsAuthNumberGetRequest;
 import com.zipkimi.user.dto.request.SmsAuthNumberPostRequest;
+import com.zipkimi.user.dto.response.SmsAuthNumberGetResponse;
 import com.zipkimi.user.dto.response.SmsAuthNumberPostResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -9,6 +11,8 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,4 +34,14 @@ public class BuilderManagementController {
         return ResponseEntity.status(HttpStatus.OK).body(builderManagementService.sendBuilderUserJoinSmsAuthNumber(requestDto));
     }
 
+    @ApiOperation(value = "SMS 인증번호 확인")
+    @GetMapping(value = "/sms")
+    public ResponseEntity<SmsAuthNumberGetResponse> checkBuilderUserJoinSmsAuthNumber(
+            @ModelAttribute
+            SmsAuthNumberGetRequest requestDto) {
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(builderManagementService.checkBuilderUserJoinSmsAuthNumber(requestDto));
+
+    }
 }

--- a/src/main/java/com/zipkimi/builder/service/BuilderManagementService.java
+++ b/src/main/java/com/zipkimi/builder/service/BuilderManagementService.java
@@ -103,7 +103,6 @@ public class BuilderManagementService {
 
                 // SMS 전송 로직
                 smsService.pushSMSMessage(smsAuthEntitySaved);
-                System.out.println("!!!!!!!!!! smsAuthEntitySaved1 = " + smsAuthEntitySaved);
 
             } catch (Exception e) {
                 throw new BadRequestException("SMS 인증번호를 생성하던 중 오류가 발생하였습니다.");

--- a/src/main/java/com/zipkimi/builder/service/BuilderManagementService.java
+++ b/src/main/java/com/zipkimi/builder/service/BuilderManagementService.java
@@ -13,7 +13,9 @@ import com.zipkimi.repository.BuilderRepository;
 import com.zipkimi.repository.BuilderUserRepository;
 import com.zipkimi.repository.SmsAuthRepository;
 import com.zipkimi.repository.UserRepository;
+import com.zipkimi.user.dto.request.SmsAuthNumberGetRequest;
 import com.zipkimi.user.dto.request.SmsAuthNumberPostRequest;
+import com.zipkimi.user.dto.response.SmsAuthNumberGetResponse;
 import com.zipkimi.user.dto.response.SmsAuthNumberPostResponse;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -42,20 +44,23 @@ public class BuilderManagementService {
             SmsAuthNumberPostRequest requestDto) {
 
         // 휴대폰 번호 유효성 검사 - 타입, 글자수, 이미 등록된 번호인지 체크
-        String phoneNumber = requestDto.getPhoneNumber().replaceAll("\\D", ""); // "\\D" 정규식을 사용하여 숫자이외의 문자는 모두 ""으로 변경
+        String phoneNumber = requestDto.getPhoneNumber()
+                .replaceAll("\\D", ""); // "\\D" 정규식을 사용하여 숫자이외의 문자는 모두 ""으로 변경
         if (phoneNumber == null || !isValidPhoneNumber(phoneNumber)) {
             return SmsAuthNumberPostResponse.builder()
                     .message("휴대폰 번호를 정확히 입력해주세요.")
                     .build();
         }
 
-        // 시공사 회원 중복 확인
-        Optional<BuilderUserEntity> builderUser = builderUserRepository.findByPhoneNumberAndIsUseIsTrue(phoneNumber);
-        // 일반 회원 중복 확인
-        Optional<UserEntity> user = userRepository.findByPhoneNumberAndIsUseIsTrue(phoneNumber);
+        // 휴대폰번호 & 사용여부로 일반 회원 정보 조회 - 일반 회원 중복 확인
+        Optional<UserEntity> optionalUser = userRepository.findByPhoneNumberAndIsUseIsTrue(phoneNumber);
+
+        // 휴대폰번호 & 사용여부로 시공사 회원 정보 조회 - 시공사 회원 중복 확인
+        Optional<BuilderUserEntity> optionalBuilderUser = builderUserRepository.findByPhoneNumberAndIsUseIsTrue(
+                phoneNumber);
 
         // 일반 회원으로 가입된 휴대폰 번호거나, 시공사 회원으로 가입된 휴대폰 번호일 경우
-        if (builderUser.isPresent() || user.isPresent()) {
+        if (optionalBuilderUser.isPresent() || optionalUser.isPresent()) {
             return SmsAuthNumberPostResponse.builder()
                     .message("이미 등록된 휴대폰 번호입니다.")
                     .build();
@@ -68,7 +73,6 @@ public class BuilderManagementService {
 
         String randomNumber;
         SmsAuthEntity smsAuthEntitySaved = null;
-        log.info("randomNumber = {}, randomNumber");
 
         if (existingSmsAuth != null) {
             // SMS 인증번호가 만료되지 않았을 경우
@@ -84,12 +88,14 @@ public class BuilderManagementService {
             SmsAuthEntity smsAuth = new SmsAuthEntity();
             smsAuth.setPhoneNumber(phoneNumber);
             smsAuth.setSmsAuthNumber(randomNumber);
+            smsAuth.setIsUse(false);
             smsAuth.setIsAuthenticate(false);
             smsAuth.setExpirationTime(LocalDateTime.now().plusMinutes(5L));
             smsAuth.setSmsAuthType(SMS_AUTH_CODE.BUILDER_JOIN.getValue());
 
             // SMS 내용 설정
-            smsAuth.setContent("[집킴이] 본인확인 인증번호는 [" + smsAuth.getSmsAuthNumber() + "] 입니다. 인증번호를 정확히 입력해주세요.");
+            smsAuth.setContent(
+                    "[집킴이] 본인확인 인증번호는 [" + smsAuth.getSmsAuthNumber() + "] 입니다. 인증번호를 정확히 입력해주세요.");
 
             try {
                 // DB 테이블에 insert
@@ -97,6 +103,7 @@ public class BuilderManagementService {
 
                 // SMS 전송 로직
                 smsService.pushSMSMessage(smsAuthEntitySaved);
+                System.out.println("!!!!!!!!!! smsAuthEntitySaved1 = " + smsAuthEntitySaved);
 
             } catch (Exception e) {
                 throw new BadRequestException("SMS 인증번호를 생성하던 중 오류가 발생하였습니다.");
@@ -108,5 +115,51 @@ public class BuilderManagementService {
                 .message("인증번호를 전송하였습니다.")
                 .build();
     }
+
+    public SmsAuthNumberGetResponse checkBuilderUserJoinSmsAuthNumber(
+            SmsAuthNumberGetRequest requestDto) {
+
+        // #1. SMS 인증번호를 ID를 통해 DB 데이터 검증 후
+        Optional<SmsAuthEntity> smsAuth = smsAuthRepository.findById(requestDto.getSmsAuthId());
+        log.info("smsAuth ={}", smsAuth);
+        log.info("smsAuth.get().getSmsAuthNumber() ={}", smsAuth.get().getSmsAuthNumber());
+
+        if (smsAuth.isEmpty() || !smsAuth.get().getSmsAuthNumber()
+                .equals(requestDto.getSmsAuthNumber())) {
+            return SmsAuthNumberGetResponse
+                    .builder()
+                    .message("SMS 인증에 실패하였습니다. \n인증번호를 정상적으로 입력해주세요.")
+                    .build();
+        }
+
+        // 2. SMS 인증번호 만료시간 검증
+        LocalDateTime currentTime = LocalDateTime.now();
+        LocalDateTime expirationTime = smsAuth.get().getExpirationTime();
+
+        if (currentTime.isAfter(expirationTime)) {
+            return SmsAuthNumberGetResponse
+                    .builder()
+                    .message("인증번호가 만료되었습니다. \n다시 인증번호를 발급받아주세요.")
+                    .build();
+        }
+
+        if (Boolean.TRUE.equals(smsAuth.get().getIsUse())) {
+            return SmsAuthNumberGetResponse
+                    .builder()
+                    .message("이미 사용된 인증번호입니다. \n다시 인증번호를 발급받아주세요.")
+                    .build();
+        }
+
+        // SMS 인증번호를 여러 번 사용하는 것 방지
+        smsAuth.get().setIsUse(true);
+        // SMS 본인 인증 완료 여부를 true로 업데이트
+        smsAuth.get().setIsAuthenticate(true);
+        smsAuthRepository.save(smsAuth.get());
+
+        return SmsAuthNumberGetResponse.builder()
+                .message("본인 인증에 성공했습니다.")
+                .build();
+    }
+
 
 }

--- a/src/main/java/com/zipkimi/builder/service/BuilderManagementService.java
+++ b/src/main/java/com/zipkimi/builder/service/BuilderManagementService.java
@@ -96,14 +96,11 @@ public class BuilderManagementService {
 
                 // SMS 전송 로직
                 smsService.pushSMSMessage(smsAuthEntitySaved);
-                System.out.println("!!!!!!!!!! smsAuthEntitySaved1 = " + smsAuthEntitySaved);
 
             } catch (Exception e) {
                 throw new BadRequestException("SMS 인증번호를 생성하던 중 오류가 발생하였습니다.");
             }
         }
-
-        System.out.println("!!!!!!!!!! smsAuthEntitySaved2 = " + smsAuthEntitySaved);
 
         return SmsAuthNumberPostResponse.builder()
                 .smsAuthId(smsAuthEntitySaved.getSmsAuthId())

--- a/src/main/java/com/zipkimi/builder/service/BuilderManagementService.java
+++ b/src/main/java/com/zipkimi/builder/service/BuilderManagementService.java
@@ -68,6 +68,7 @@ public class BuilderManagementService {
 
         String randomNumber;
         SmsAuthEntity smsAuthEntitySaved = null;
+        log.info("randomNumber = {}, randomNumber");
 
         if (existingSmsAuth != null) {
             // SMS 인증번호가 만료되지 않았을 경우

--- a/src/main/java/com/zipkimi/builder/service/BuilderManagementService.java
+++ b/src/main/java/com/zipkimi/builder/service/BuilderManagementService.java
@@ -1,8 +1,26 @@
 package com.zipkimi.builder.service;
 
+import static com.zipkimi.global.utils.CommonUtils.generateNumber;
+import static com.zipkimi.global.utils.RegexUtils.isValidPhoneNumber;
+
+import com.zipkimi.entity.BuilderUserEntity;
+import com.zipkimi.entity.SmsAuthEntity;
+import com.zipkimi.entity.UserEntity;
+import com.zipkimi.global.exception.BadRequestException;
+import com.zipkimi.global.service.SmsService;
+import com.zipkimi.global.utils.CodeConstant.SMS_AUTH_CODE;
+import com.zipkimi.repository.BuilderRepository;
+import com.zipkimi.repository.BuilderUserRepository;
+import com.zipkimi.repository.SmsAuthRepository;
+import com.zipkimi.repository.UserRepository;
+import com.zipkimi.user.dto.request.SmsAuthNumberPostRequest;
+import com.zipkimi.user.dto.response.SmsAuthNumberPostResponse;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import javax.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -10,5 +28,87 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 @Transactional(rollbackOn = Exception.class)
 public class BuilderManagementService {
+
+    private final BuilderRepository builderRepository;
+    private final BuilderUserRepository builderUserRepository;
+    private final UserRepository userRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    private final SmsAuthRepository smsAuthRepository;
+    private final SmsService smsService;
+
+    public SmsAuthNumberPostResponse sendBuilderUserJoinSmsAuthNumber(
+            SmsAuthNumberPostRequest requestDto) {
+
+        // 휴대폰 번호 유효성 검사 - 타입, 글자수, 이미 등록된 번호인지 체크
+        String phoneNumber = requestDto.getPhoneNumber().replaceAll("\\D", ""); // "\\D" 정규식을 사용하여 숫자이외의 문자는 모두 ""으로 변경
+        if (phoneNumber == null || !isValidPhoneNumber(phoneNumber)) {
+            return SmsAuthNumberPostResponse.builder()
+                    .message("휴대폰 번호를 정확히 입력해주세요.")
+                    .build();
+        }
+
+        // 시공사 회원 중복 확인
+        Optional<BuilderUserEntity> builderUser = builderUserRepository.findByPhoneNumberAndIsUseIsTrue(phoneNumber);
+        // 일반 회원 중복 확인
+        Optional<UserEntity> user = userRepository.findByPhoneNumberAndIsUseIsTrue(phoneNumber);
+
+        // 일반 회원으로 가입된 휴대폰 번호거나, 시공사 회원으로 가입된 휴대폰 번호일 경우
+        if (builderUser.isPresent() || user.isPresent()) {
+            return SmsAuthNumberPostResponse.builder()
+                    .message("이미 등록된 휴대폰 번호입니다.")
+                    .build();
+        }
+
+        // 휴대폰번호/인증완료여부/만료시간만료여부/인증타입으로 만료되지 않은 인증번호 있는지 조회
+        SmsAuthEntity existingSmsAuth =
+                smsAuthRepository.findValidSmsAuthByPhoneNumberAndType(phoneNumber,
+                        LocalDateTime.now(), SMS_AUTH_CODE.BUILDER_JOIN.getValue());
+
+        String randomNumber;
+        SmsAuthEntity smsAuthEntitySaved = null;
+
+        if (existingSmsAuth != null) {
+            // SMS 인증번호가 만료되지 않았을 경우
+            existingSmsAuth.setExpirationTime(LocalDateTime.now().plusMinutes(5L));
+            smsAuthRepository.save(existingSmsAuth);
+            return SmsAuthNumberPostResponse.builder()
+                    .message("유효시간이 만료되지 않은 인증번호가 존재합니다. \n인증번호를 확인하거나, 유효시간이 지난 후 다시 시도해주세요.")
+                    .build();
+        } else {
+            // 인증번호 생성 : 4자리(중복 x)
+            randomNumber = generateNumber(4, 2);
+
+            SmsAuthEntity smsAuth = new SmsAuthEntity();
+            smsAuth.setPhoneNumber(phoneNumber);
+            smsAuth.setSmsAuthNumber(randomNumber);
+            smsAuth.setIsAuthenticate(false);
+            smsAuth.setExpirationTime(LocalDateTime.now().plusMinutes(5L));
+            smsAuth.setSmsAuthType(SMS_AUTH_CODE.BUILDER_JOIN.getValue());
+
+            // SMS 내용 설정
+            smsAuth.setContent("[집킴이] 본인확인 인증번호는 [" + smsAuth.getSmsAuthNumber() + "] 입니다. 인증번호를 정확히 입력해주세요.");
+
+            try {
+                // DB 테이블에 insert
+                smsAuthEntitySaved = smsAuthRepository.save(smsAuth);
+
+                // SMS 전송 로직
+                smsService.pushSMSMessage(smsAuthEntitySaved);
+                System.out.println("!!!!!!!!!! smsAuthEntitySaved1 = " + smsAuthEntitySaved);
+
+            } catch (Exception e) {
+                throw new BadRequestException("SMS 인증번호를 생성하던 중 오류가 발생하였습니다.");
+            }
+        }
+
+        System.out.println("!!!!!!!!!! smsAuthEntitySaved2 = " + smsAuthEntitySaved);
+
+        return SmsAuthNumberPostResponse.builder()
+                .smsAuthId(smsAuthEntitySaved.getSmsAuthId())
+                .message("인증번호를 전송하였습니다.")
+                .build();
+    }
 
 }

--- a/src/main/java/com/zipkimi/entity/BuilderEntity.java
+++ b/src/main/java/com/zipkimi/entity/BuilderEntity.java
@@ -28,43 +28,43 @@ public class BuilderEntity extends BaseEntity {
     private Long id;
 
     @Column(name = "builder_name")
-    private String builder_name;
+    private String builderName;
 
     @Column(name = "status")
     private String status;  //요청, 취소, 승인완료, 승인거절, 재요청
 
     @Column(name = "builder_number")
-    private String builder_number;
+    private String builderNumber;
 
     @Column(name = "builder_com_number")
-    private String builder_com_number;
+    private String builderComNumber;
 
     @Column(name = "representative_name")
-    private String representative_name;
+    private String representativeName;
 
     @Column(name = "builder_contact_number")
-    private String builder_contact_number;
+    private String builderContactNumber;
 
     @Column(name = "taxation")
     private String taxation;    //과세구분 (일반과세자, 간이과세자, 법인과세자, 면세법인 사업자)
 
     @Column(name = "business_item")
-    private String business_item;   //종목 (개인대표, 공동대표)
+    private String businessItem;   //종목 (개인대표, 공동대표)
 
     @Column(name = "representative_division")
-    private String representative_division; //대표자 구분 (개인대표, 공동대표)
+    private String representativeDivision; //대표자 구분 (개인대표, 공동대표)
 
     @Column(name = "representative_birth_date")
-    private String representative_birth_date;
+    private String representativeBirthDate;
 
     @Column(name = "business_location")
-    private String business_location;
+    private String businessLocation;
 
     @Column(name = "zip_code")
-    private String zip_code;
+    private String zipCode;
 
     @Column(name = "image_id")
-    private Long image_id;
+    private Long imageId;
 
 
 }

--- a/src/main/java/com/zipkimi/entity/BuilderUserEntity.java
+++ b/src/main/java/com/zipkimi/entity/BuilderUserEntity.java
@@ -32,8 +32,8 @@ public class BuilderUserEntity extends BaseEntity {
     //TODO builder와 연관 관계 맵핑 필요
     private Long builderId;
 
-    @Column(name = "id")
-    private String id;
+    @Column(name = "email")
+    private String email;
 
     @Column(name = "password")
     private String password;

--- a/src/main/java/com/zipkimi/entity/BuilderUserEntity.java
+++ b/src/main/java/com/zipkimi/entity/BuilderUserEntity.java
@@ -2,6 +2,8 @@ package com.zipkimi.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -27,6 +29,9 @@ public class BuilderUserEntity extends BaseEntity {
     @Column(name = "builder_member_id")
     private Long builderMemberId;
 
+    //TODO builder와 연관 관계 맵핑 필요
+    private Long builderId;
+
     @Column(name = "id")
     private String id;
 
@@ -39,5 +44,8 @@ public class BuilderUserEntity extends BaseEntity {
     @Column(name = "is_use", columnDefinition = "true")
     private boolean isUse;
 
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING) //저장될때는 String 으로 저장되도록
+    private UserRole role;
 
 }

--- a/src/main/java/com/zipkimi/global/config/SecurityConfig.java
+++ b/src/main/java/com/zipkimi/global/config/SecurityConfig.java
@@ -61,6 +61,9 @@ public class SecurityConfig  {
                 .antMatchers("/api/v1/users/find-pw/**").permitAll()
                 .antMatchers("/exception/**").permitAll()
 
+                //시공사 회원 관련 접근 허용 추가
+                .antMatchers("/api/v1/builderMgmt/builders/**").permitAll()
+
                 // 만약, 권한별 접근 설정을 하고 싶으면 hasRole 사용
                 // 특정 요청에 대한 권한 체크 (ROLE이 USER일 때만 이용 가능)
                 //.antMatchers("/api/v1/users/**").hasRole("USER")

--- a/src/main/java/com/zipkimi/global/utils/CodeConstant.java
+++ b/src/main/java/com/zipkimi/global/utils/CodeConstant.java
@@ -19,7 +19,10 @@ public class CodeConstant {
         FIND_ID("findId"),
 
         //비밀번호 찾기
-        FIND_PW("findPw");
+        FIND_PW("findPw"),
+
+        //시공사 회원가입
+        BUILDER_JOIN("builderJoin");
 
         final String value;
     }

--- a/src/main/java/com/zipkimi/global/utils/CommonUtils.java
+++ b/src/main/java/com/zipkimi/global/utils/CommonUtils.java
@@ -1,0 +1,40 @@
+package com.zipkimi.global.utils;
+
+import java.util.Random;
+
+/**
+ * 공통적으로 사용하는 유틸 클래스
+ */
+public class CommonUtils {
+
+    private static final Random random = new Random();
+
+    // 난수로 인증번호 생성
+    public static String generateNumber(int len, int dupCd) {
+
+        //난수가 저장될 변수
+        StringBuilder numStr = new StringBuilder();
+
+        for (int i = 0; i < len; i++) {
+
+            //0~9 까지 난수 생성
+            String ran = Integer.toString(random.nextInt(10));
+
+            if (dupCd == 1) {
+                //중복 허용시 numStr 변수에 append
+                numStr.append(ran);
+            } else if (dupCd == 2) {
+                //중복을 허용하지 않을시 중복된 값이 있는지 검사한다
+                if (!numStr.toString().contains(ran)) {
+                    //중복된 값이 없으면 numStr 변수에  append
+                    numStr.append(ran);
+                } else {
+                    //생성된 난수가 중복되면 루틴을 다시 실행한다
+                    i -= 1;
+                }
+            }
+        }
+        return numStr.toString();
+    }
+
+}

--- a/src/main/java/com/zipkimi/global/utils/CommonUtils.java
+++ b/src/main/java/com/zipkimi/global/utils/CommonUtils.java
@@ -1,13 +1,14 @@
 package com.zipkimi.global.utils;
 
 import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * 공통적으로 사용하는 유틸 클래스
  */
 public class CommonUtils {
 
-    private static final Random random = new Random();
+    private static final RandomGenerator randomGenerator = new Random();
 
     // 난수로 인증번호 생성
     public static String generateNumber(int len, int dupCd) {
@@ -18,7 +19,7 @@ public class CommonUtils {
         for (int i = 0; i < len; i++) {
 
             //0~9 까지 난수 생성
-            String ran = Integer.toString(random.nextInt(10));
+            String ran = Integer.toString(randomGenerator.nextInt(10));
 
             if (dupCd == 1) {
                 //중복 허용시 numStr 변수에 append

--- a/src/main/java/com/zipkimi/repository/BuilderUserRepository.java
+++ b/src/main/java/com/zipkimi/repository/BuilderUserRepository.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BuilderUserRepository extends JpaRepository<BuilderUserEntity, Long> {
 
-    Optional<BuilderUserEntity> findByIdAndIsUseIsTrue(String id);
-
     Optional<BuilderUserEntity> findByPhoneNumberAndIsUseIsTrue(String phoneNumber);
+
 }

--- a/src/main/java/com/zipkimi/repository/BuilderUserRepository.java
+++ b/src/main/java/com/zipkimi/repository/BuilderUserRepository.java
@@ -10,5 +10,5 @@ public interface BuilderUserRepository extends JpaRepository<BuilderUserEntity, 
 
     Optional<BuilderUserEntity> findByIdAndIsUseIsTrue(String id);
 
-
+    Optional<BuilderUserEntity> findByPhoneNumberAndIsUseIsTrue(String phoneNumber);
 }

--- a/src/main/java/com/zipkimi/user/service/UserLoginService.java
+++ b/src/main/java/com/zipkimi/user/service/UserLoginService.java
@@ -1,5 +1,7 @@
 package com.zipkimi.user.service;
 
+import static com.zipkimi.global.utils.CommonUtils.generateNumber;
+
 import com.zipkimi.entity.SmsAuthEntity;
 import com.zipkimi.entity.UserEntity;
 import com.zipkimi.entity.UserRole;
@@ -24,7 +26,6 @@ import com.zipkimi.user.dto.response.FindSmsAuthNumberPostResponse;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.Optional;
-import java.util.Random;
 import javax.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,7 +51,6 @@ public class UserLoginService {
     /* JWT Refresh 토큰 Repository */
     private final RefreshTokenRepository refreshTokenRepository;
     private final SmsService smsService;
-    private final Random random = new Random();
 
     /* JWT 관련 */
     private final PasswordEncoder passwordEncoder;
@@ -479,36 +479,6 @@ public class UserLoginService {
         //TODO SNS 가입자인 경우 : SNS 로그인 개발 후 추가 필요
         // 네이버 가입자입니다. 네이버로 로그인해주세요.
 
-    }
-
-    // ************* 공통 로직 *************
-
-    //난수로 인증번호 생성
-    public String generateNumber(int len, int dupCd) {
-
-        //난수가 저장될 변수
-        StringBuilder numStr = new StringBuilder();
-
-        for (int i = 0; i < len; i++) {
-
-            //0~9 까지 난수 생성
-            String ran = Integer.toString(random.nextInt(10));
-
-            if (dupCd == 1) {
-                //중복 허용시 numStr 변수에 append
-                numStr.append(ran);
-            } else if (dupCd == 2) {
-                //중복을 허용하지 않을시 중복된 값이 있는지 검사한다
-                if (!numStr.toString().contains(ran)) {
-                    //중복된 값이 없으면 numStr 변수에  append
-                    numStr.append(ran);
-                } else {
-                    //생성된 난수가 중복되면 루틴을 다시 실행한다
-                    i -= 1;
-                }
-            }
-        }
-        return numStr.toString();
     }
 
     //임시 비밀번호 생성


### PR DESCRIPTION
## 작업 내용
- BuilderUserEntity 컬럼 수정
- BuilderManagementService checkBuilderUserJoinSmsAuthNumber 메서드 추가
- BuilderManagementController checkBuilderUserJoinSmsAuthNumber 메서드 추가
- BuilderUserRepository findByIdAndIsUseIsTrue 메서드 삭제

<br><br>

## 참고 사항
깃 포크 이슈로 커밋/푸쉬가 조금 꼬여 이전 커밋들이 포함되어 있습니다.
Refactor : BuilderManagementService System.out 로그 출력 추가 (ea55de54bc26d2b65e046e10c7556e69a82f051f)
이후 커밋 중점으로 봐주시면 감사하겠습니다.

<br><br>

## 관련 이슈

- Close #40

<br><br>

